### PR TITLE
update twitter search API call from 500ms to 6000ms (60 seconds.) 

### DIFF
--- a/default.py
+++ b/default.py
@@ -156,11 +156,11 @@ while (not xbmc.abortRequested):
 					xbmc.sleep(wait_time)
 					old_text = text
 				else:
-					xbmc.sleep(500)
+					xbmc.sleep(6000)
 			except:
 				xbmc.log('No Twitter Results, URL = '+'http://www.twitter.com/search?q='+search_string+'&f=realtime')
 				xbmc.executebuiltin('XBMC.Notification("%s", "%s")' % (translation(30017),translation(30018)))
-				xbmc.sleep(500)			
+				xbmc.sleep(6000)			
 		
 		else:
 			xbmc.sleep(1000)


### PR DESCRIPTION
Ryan from Twitter here. I'm hoping to updat the twitter search API call from 500ms to 6000ms (60 seconds). This is to avoid throttling/rate limiting of API requests, but still provide a decent user experience.

I would actually also love to see this in action, if possible. Happy to talk at @rchoi or rchoi@twitter.com

Thanks for building with Twitter, and hope to hear from you, asojka09!
